### PR TITLE
ADR-2034 Fix issue on View payments page on 1st of month

### DIFF
--- a/src/test/resources/features/commonPageFeatures/ViewPastPaymentsPage.feature
+++ b/src/test/resources/features/commonPageFeatures/ViewPastPaymentsPage.feature
@@ -16,23 +16,23 @@ Feature: View Past Payments Journey
     Then I verify the due amount displayed as "You owe £3,325.44" on "View Past Payments Page"
     And I should see the below details at "Unallocated" section on "View Past Payments Page" with "FullDate"
       | Payment date  | Description | Amount     | Action       |
-      | 1CurrentMonth  | Payment     | −£1,000.00 | Claim refund |
+      | 1CurrentMonth | Payment     | −£1,000.00 | Claim refund |
       | 1Minus1Months | Payment     | −£500.00   | Claim refund |
     And I should see the below details at "Outstanding" section on "View Past Payments Page" with "FullDate"
-      | To be paid by  | Description                     | Left to pay | Status         | Action       |
-      | 25Plus1Months  | Payment for Alcohol Duty return | £237.44     | Due            | Pay now      |
-      | CurrentMonth   | Late payment interest charge    | £20.56      | Due            | Pay now      |
-      | 25Minus2Months | Payment for Alcohol Duty return | £4,577.44   | Overdue        | Pay now      |
-      | 25Minus3Months | Payment for Alcohol Duty return | £2,577.44   | Overdue        | Pay now      |
-      | 25Minus4Months | Credit for Alcohol Duty return  | −£2,577.44  | Nothing to pay | Claim refund |
-      | 1Minus5Months  | Refund payment interest charge  | −£20.56     | Nothing to pay | Claim refund |
-      | 1Minus6Months  | Late payment interest charge    | £10.56      | Overdue        | Pay now      |
+      | To be paid by       | Description                     | Left to pay | Status         | Action       |
+      | 25Plus1Months       | Payment for Alcohol Duty return | £237.44     | Due            | Pay now      |
+      | CurrentDateAndMonth | Late payment interest charge    | £20.56      | Due            | Pay now      |
+      | 25Minus2Months      | Payment for Alcohol Duty return | £4,577.44   | Overdue        | Pay now      |
+      | 25Minus3Months      | Payment for Alcohol Duty return | £2,577.44   | Overdue        | Pay now      |
+      | 25Minus4Months      | Credit for Alcohol Duty return  | −£2,577.44  | Nothing to pay | Claim refund |
+      | 1Minus5Months       | Refund payment interest charge  | −£20.56     | Nothing to pay | Claim refund |
+      | 1Minus6Months       | Late payment interest charge    | £10.56      | Overdue        | Pay now      |
     And I should see the below details at "Historical" section on "View Past Payments Page" with "MonthYear"
-      | Return period | Description                                   | Amount    |
-      | CurrentMonth  | Cleared late payment interest charge payments | £20.56    |
-      | 1Minus3Months | Cleared Alcohol Duty payments                 | £4,577.44 |
-      | 1Minus4Months | Cleared Alcohol Duty payments                 | £2,000.00 |
-      | 1Minus6Months | Cleared late payment interest charge payments | £10.00    |
+      | Return period       | Description                                   | Amount    |
+      | CurrentDateAndMonth | Cleared late payment interest charge payments | £20.56    |
+      | 1Minus3Months       | Cleared Alcohol Duty payments                 | £4,577.44 |
+      | 1Minus4Months       | Cleared Alcohol Duty payments                 | £2,000.00 |
+      | 1Minus6Months       | Cleared late payment interest charge payments | £10.00    |
 
   Scenario: 2. ADR Journey - Verify that year 2025 data is visible under historical payments section
     Given I cleared the data for the service
@@ -49,11 +49,11 @@ Feature: View Past Payments Journey
     Then I verify the due amount displayed as "You owe £43,556.88" on "View Past Payments Page"
 #    For the below step, two values under return period are dynamic and the rest of the two values are static
     And I should see the below details at "Historical" section on "View Past Payments Page" with "MonthYear"
-      | Return period  | Description                                   | Amount    |
-      | September 2025 | Cleared Alcohol Duty payments                 | £1,234.44 |
-      | CurrentMonth   | Cleared Alcohol Duty payments                 | £237.44   |
-      | 1Minus1Months  | Cleared late payment interest charge payments | £20.56    |
-      | November 2024  | Cleared Alcohol Duty payments                 | £2,307.44 |
+      | Return period       | Description                                   | Amount    |
+      | September 2025      | Cleared Alcohol Duty payments                 | £1,234.44 |
+      | CurrentDateAndMonth | Cleared Alcohol Duty payments                 | £237.44   |
+      | 1Minus1Months       | Cleared late payment interest charge payments | £20.56    |
+      | November 2024       | Cleared Alcohol Duty payments                 | £2,307.44 |
 
   Scenario: 3. ADR Journey - To verify the View Past Payments Page in case of no outstanding payments or NOT_FOUND error
     Given I cleared the data for the service

--- a/src/test/resources/features/quarterlySpiritsQuestionsJourney/QuarterlySpiritsQuestionsChangeLinksCYAPage.feature
+++ b/src/test/resources/features/quarterlySpiritsQuestionsJourney/QuarterlySpiritsQuestionsChangeLinksCYAPage.feature
@@ -78,7 +78,7 @@ Feature: Quarterly Spirits Journey - Change Links - CYA Page
     And I select Affinity Type as "Organisation" on "Auth Login Stub Page"
     And I enter Enrollment Key "HMRC-AD-ORG", Identifier Name "APPAID" and Identifier Value "AABCP0000100208" on "Auth Login Stub Page"
     And I click submit button on "Auth Login Stub Page"
-   And  I verify the return due date for "Previous Spirits Month Selected" on "Before You Start Page"
+    And I verify the return due date for "Latest Month Selected" on "Before You Start Page"
     When I click continue button on "Before You Start Page"
     Then I am presented with the "Task List Page"
     And I should see the following subsections

--- a/src/test/scala/uk/gov/hmrc/alcoholDuty/cucumber/stepdefs/BaseStepDef.scala
+++ b/src/test/scala/uk/gov/hmrc/alcoholDuty/cucumber/stepdefs/BaseStepDef.scala
@@ -30,7 +30,6 @@ import uk.gov.hmrc.alcoholDuty.pages.generic.PageObjectFinder
 import uk.gov.hmrc.alcoholDuty.pages.generic.PageObjectFinder.DataTableConverters
 
 import java.time.LocalDate
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 trait BaseStepDef
@@ -177,11 +176,11 @@ trait BaseStepDef
 
   When("""I enter redirect url for {string}""") { (page: String) =>
     page match {
-      case "Task List Page"            =>
+      case "Task List Page" =>
         driver.get(TestConfiguration.url("alcohol-duty-returns-frontend") + "/complete-return/task-list")
-      case "Return Summary Page"       =>
+      case "Return Summary Page" =>
         driver.get(TestConfiguration.url("alcohol-duty-returns-frontend") + "/complete-return/check-return")
-      case "Alcohol Duty Service"      =>
+      case "Alcohol Duty Service" =>
         driver.get(
           TestConfiguration.url("alcohol-duty-returns-frontend") + "/before-you-start-your-return/" + periodKey
         )
@@ -195,14 +194,9 @@ trait BaseStepDef
 //            "alcohol-duty-returns-frontend"
 //          ) + "/before-you-start-your-return/" + previousPeriodKey
 
-//      case "December Period Key" =>
-//        val url =
-//          s"http://localhost:9949/auth-login-stub/gg-sign-in?continue=http%3A%2F%2Flocalhost%3A16000%2Fmanage-alcohol-duty%2Fbefore-you-start-your-return%2F$decemberPeriodKey"
-//        driver.get(url)
-
       case "Previous Spirits Period Key" =>
         val url =
-          s"http://localhost:9949/auth-login-stub/gg-sign-in?continue=http%3A%2F%2Flocalhost%3A16000%2Fmanage-alcohol-duty%2Fbefore-you-start-your-return%2F$previousSpiritsPeriodKey"
+          s"http://localhost:9949/auth-login-stub/gg-sign-in?continue=http%3A%2F%2Flocalhost%3A16000%2Fmanage-alcohol-duty%2Fbefore-you-start-your-return%2F$periodKey"
         driver.get(url)
     }
   }
@@ -335,6 +329,7 @@ trait BaseStepDef
     val actualText = driver.findElement(By.xpath("//div/div/form/p[1]")).getText
 
     content match {
+      // This is the most recent month with quarterly spirits
       case "Latest Month Selected" =>
         actualText should be(
           "Use this service to submit your Alcohol Duty Return for " + getDateRange + "."
@@ -343,14 +338,6 @@ trait BaseStepDef
       case "Previous Month Selected"         =>
         actualText should be(
           "Use this service to submit your Alcohol Duty Return for " + firstDayOfPreviousMonth + " to " + lastDayOfPreviousMonth + "."
-        )
-//      case "December Return Selected" =>
-//        actualText should be(
-//          "Use this service to submit your Alcohol Duty Return for " + firstDayOfDecember + " to " + lastDayOfDecember + "."
-//        )
-      case "Previous Spirits Month Selected" =>
-        actualText should be(
-          "Use this service to submit your Alcohol Duty Return for " + firstDayOfPreviousSpiritsMonth + " to " + lastDayOfPreviousSpiritsMonth + "."
         )
     }
   }

--- a/src/test/scala/uk/gov/hmrc/alcoholDuty/pages/BasePage.scala
+++ b/src/test/scala/uk/gov/hmrc/alcoholDuty/pages/BasePage.scala
@@ -592,18 +592,17 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
     }
 
     // Generate keys for all days (1 to 31) and special cases like "currentMonth"
-    val monthOffsets = (-10 to 10).flatMap { offset =>
+    val monthOffsets: Seq[(String, String)] = (-10 to 10).flatMap { offset =>
       (1 to 31).map { day =>
         val key =
-          if (day == currentDate.getDayOfMonth && offset == 0) "CurrentMonth" // Handle "currentMonth" key
-          else if (offset < 0) s"${day}Minus${-offset}Months"
+          if (offset < 0) s"${day}Minus${-offset}Months"
           else if (offset > 0) s"${day}Plus${offset}Months"
           else s"${day}CurrentMonth"
         key -> computeDate(day, offset)
       }
-    }.toMap
+    } ++ Seq("CurrentMonth" -> computeDate(currentDate.getDayOfMonth, 0)) // Handle "CurrentMonth" key
 
-    monthOffsets
+    monthOffsets.toMap
   }
 
 

--- a/src/test/scala/uk/gov/hmrc/alcoholDuty/pages/BasePage.scala
+++ b/src/test/scala/uk/gov/hmrc/alcoholDuty/pages/BasePage.scala
@@ -226,7 +226,6 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
   def periodKey: String = {
 
     val currentMonth = LocalDate.now().getMonthValue
-    val currentYear = LocalDate.now().getYear
     val adjustedYear = if (Month == 1) year - 1 else year
     val yearSuffix = adjustedYear.toString.takeRight(2) // Last two digits of the year
 
@@ -238,15 +237,13 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
     }
 
     // Generate period key based on the first month of the current quarter
+    // This is the most recent month with quarterly spirits
     firstMonthOfQuarter match {
       case 1 => s"${(adjustedYear - 1).toString.takeRight(2)}AL" // First month of Q1 -> AL
       case 4 => s"${yearSuffix}AC" // First month of Q2 -> AC
       case 7 => s"${yearSuffix}AF" // First month of Q3 -> AF
       case 10 => s"${yearSuffix}AI" // First month of Q4 -> AI
     }
-
-
-
 
     //      case 2 | 3 | 4   => s"${yearSuffix}AA"
     //      case 5 | 6 | 7   => s"${yearSuffix}AD"
@@ -264,7 +261,7 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
     val year = currentDate.getYear
 
     // Determine the base year suffix
-    val yearSuffix = if (month == 12||month == 1||month == 2||month == 3) (year - 1).toString.takeRight(2) else year.toString.takeRight(2)
+    val yearSuffix = if (month == 1||month == 2||month == 3) (year - 1).toString.takeRight(2) else year.toString.takeRight(2)
 
     // Determine the previous period key based on the month
     val previousPeriodKey = month match {
@@ -289,43 +286,6 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
 
     previousPeriodKey
   }
-
-  def previousSpiritsPeriodKey: String = {
-    val currentDate = LocalDate.now()
-    val month = currentDate.getMonthValue
-    val year = currentDate.getYear
-
-    // Determine the base year suffix
-    val yearSuffix = if (month == 1||month == 2||month == 3) (year - 1).toString.takeRight(2) else year.toString.takeRight(2)
-
-    // Determine the previous spirits period key based on the month
-    val previousSpiritsPeriodKey = month match {
-      // Quarter 1 (Jan-Mar) -> Previous spirits period is December
-      case 1 | 2| 3=> s"${yearSuffix}AL"
-
-      // Quarter 2 (Apr-Jun) -> Previous spirits period is March
-      case 4 |5 | 6 => s"${yearSuffix}AC"
-
-
-      // Quarter 3 (Jul-Sep) -> Previous spirits period is June
-      case 7 |8 | 9=> s"${yearSuffix}AF"
-
-
-      // Quarter 4 (Oct-Dec) -> Previous spirits period is September
-      case 10| 11| 12 => s"${yearSuffix}AI"
-
-
-      case _ => throw new IllegalArgumentException("Invalid month value. Valid values are 1 to 12.")
-    }
-
-    previousSpiritsPeriodKey
-  }
-
-
-//  def decemberPeriodKey: String = {
-//    val lastYear = LocalDate.now().plusYears(-1).getYear.toString.takeRight(2)
-//    s"${lastYear}AL"
-//  }
 
 
   def generateYear(Year: Int): Int =
@@ -380,33 +340,15 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
   val firstDayOfNextMonth: LocalDate = currentDate.withMonth(generateMonth(Month: Int) + 1) withDayOfMonth 1
   val firstDayCurrentMonth: LocalDate = currentDate.withMonth(generateMonth(Month: Int)) withDayOfMonth 1
 
-    val firstDayOfPreviousMonth: String = currentDate
-      .withMonth(generatedMonth)
-      .withDayOfMonth(1)
-      .minusMonths(2)
-      .format(DateTimeFormatter.ofPattern("d MMMM yyyy").withLocale(Locale.UK))
-
-  val lastDayOfPreviousMonth: String  =
-    firstDayCurrentMonth.minusDays(1).minusMonths(1)format(DateTimeFormatter.ofPattern("d MMMM yyyy").withLocale(Locale.UK))
-
-//  val firstDayOfDecember: String  =
-//   LocalDate.of(previousYear,12,1)
-//     .format(DateTimeFormatter.ofPattern("d MMMM yyyy").withLocale(Locale.UK))
-//
-//  val lastDayOfDecember: String  =
-//    LocalDate.of(previousYear,12,31)
-//      .format(DateTimeFormatter.ofPattern("d MMMM yyyy").withLocale(Locale.UK))
-
-  val firstDayOfPreviousSpiritsMonth: String = currentDate
+  val firstDayOfPreviousMonth: String = currentDate
     .withMonth(generatedMonth)
     .withDayOfMonth(1)
-    .minusMonths(1)
+    .minusMonths(2)
     .format(DateTimeFormatter.ofPattern("d MMMM yyyy").withLocale(Locale.UK))
 
-  val lastDayOfPreviousSpiritsMonth: String = currentDate
-    .withMonth(generatedMonth)
-    .withDayOfMonth(1)
+  val lastDayOfPreviousMonth: String  = firstDayCurrentMonth
     .minusDays(1)
+    .minusMonths(1)
     .format(DateTimeFormatter.ofPattern("d MMMM yyyy").withLocale(Locale.UK))
 
   val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MMMM yyyy").withLocale(Locale.UK)
@@ -591,7 +533,7 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
       targetDate.withDayOfMonth(adjustedDay).format(formatter)
     }
 
-    // Generate keys for all days (1 to 31) and special cases like "currentMonth"
+    // Generate keys for all days (1 to 31) and special cases like "CurrentDateAndMonth"
     val monthOffsets: Seq[(String, String)] = (-10 to 10).flatMap { offset =>
       (1 to 31).map { day =>
         val key =
@@ -600,7 +542,7 @@ trait BasePage extends Page with Matchers with BrowserDriver with Eventually wit
           else s"${day}CurrentMonth"
         key -> computeDate(day, offset)
       }
-    } ++ Seq("CurrentMonth" -> computeDate(currentDate.getDayOfMonth, 0)) // Handle "CurrentMonth" key
+    } ++ Seq("CurrentDateAndMonth" -> computeDate(currentDate.getDayOfMonth, 0))
 
     monthOffsets.toMap
   }


### PR DESCRIPTION
Create the key `CurrentMonth` separately from `1CurrentMonth`, `2CurrentMonth` etc. (and rename it to `CurrentDateAndMonth`), so that both `CurrentDateAndMonth` and `1CurrentMonth` exist and can be looked up on the 1st of the month.

Edits to quarterly spirits:
Noticed that `periodKey` is already for the most recent spirits month, so we can use that instead of also having `previousSpiritsPeriodKey`.
Similarly, `getDateRange` already gets the first and last days of the most recent spirits month, so we don't need `firstDayOfPreviousSpiritsMonth` and `lastDayOfPreviousSpiritsMonth`.